### PR TITLE
sys.version_info is already a sequence of ints

### DIFF
--- a/ox_profile/core/sampling.py
+++ b/ox_profile/core/sampling.py
@@ -3,7 +3,6 @@
 
 import doctest
 import logging
-import platform
 import sys
 
 from ox_profile.core import metrics
@@ -15,9 +14,7 @@ class Freezer(object):
     trying to capture profiling information for safety
     """
     def __init__(self):
-        python_version_list = [
-            int(i) for i in platform.python_version().split('.')]
-        if python_version_list >= [3, 2, 0]:
+        if sys.version_info >= (3, 2, 0):
             # https://docs.python.org/3/library/sys.html#sys.setswitchinterval
             # New in version 3.2.
             self._get_interval = sys.getswitchinterval


### PR DESCRIPTION
But also, maybe we don't need to think about Python 3.2 anymore?

BTW, the old code failed on "3.14.0a5" because it tried `int("0a5")`.